### PR TITLE
Update dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ structlog = "^20.1.0"
 aiohttp = ">=3"
 
 [tool.poetry.dev-dependencies]
-jinja2 = "^3.1.2"
+jinja2 = "<3.1"
 pytest = "^6.0.1"
 pytest-asyncio = "^0.14.0"
 sphinx = "^3.2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ structlog = "^20.1.0"
 aiohttp = ">=3"
 
 [tool.poetry.dev-dependencies]
-jinja2 = "^2.11.2"
+jinja2 = "^3.1.2"
 pytest = "^6.0.1"
 pytest-asyncio = "^0.14.0"
 sphinx = "^3.2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ sphinx = "^3.2.1"
 pytest-cov = "^2.10.1"
 asyncio-extras = "^1.3.2"
 pre-commit = "^2.7.1"
-black = "^20.8b1"
+black = "^22.10.0"
 Pillow = "^8.1.0"
 
 [tool.poetry.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,10 +30,10 @@ structlog = "^20.1.0"
 aiohttp = ">=3"
 
 [tool.poetry.dev-dependencies]
-jinja2 = "<3.1"
+jinja2 = "^3.1.2"
 pytest = "^6.0.1"
 pytest-asyncio = "^0.14.0"
-sphinx = "^3.2.1"
+sphinx = "^5.2.3"
 pytest-cov = "^2.10.1"
 asyncio-extras = "^1.3.2"
 pre-commit = "^2.7.1"

--- a/src/arsenic/helpers.py
+++ b/src/arsenic/helpers.py
@@ -8,7 +8,6 @@ if sys.platform != "win32":
     def configure_ie11_environment_cli():
         pass
 
-
 else:
     import ctypes
     import winreg

--- a/src/arsenic/services.py
+++ b/src/arsenic/services.py
@@ -52,7 +52,7 @@ async def subprocess_based_service(
                     ok = False
                 if ok:
                     return
-                await asyncio.sleep(start_timeout * 2 ** i)
+                await asyncio.sleep(start_timeout * 2**i)
 
         try:
             await asyncio.wait_for(wait_service(), timeout=start_timeout)


### PR DESCRIPTION
Fixes #153 by updating `Jinja2`, `black` and `sphinx` dev dependencies to their most up to date versions.